### PR TITLE
fix: create tmp folder and remove afterwards

### DIFF
--- a/src/codesandbox/devcontainer-feature.json
+++ b/src/codesandbox/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
-    "id": "codesandbox",
-    "version": "0.1.1",
-    "name": "CodeSandbox Dev environment",
-    "documentationURL": "https://github.com/codesandbox/devcontainer-features",
-    "description": "Installs tools needed to work in CodeSandbox cloud sandboxes and repos"
+  "id": "codesandbox",
+  "version": "0.1.2",
+  "name": "CodeSandbox Dev environment",
+  "documentationURL": "https://github.com/codesandbox/devcontainer-features",
+  "description": "Installs tools needed to work in CodeSandbox cloud sandboxes and repos"
 }

--- a/src/codesandbox/install.sh
+++ b/src/codesandbox/install.sh
@@ -44,4 +44,5 @@ apt install -y \
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 chsh --shell /bin/zsh root
 
+cd /
 rm -rf /tmp/devcontainer-install/

--- a/src/codesandbox/install.sh
+++ b/src/codesandbox/install.sh
@@ -8,6 +8,7 @@ else
     DOCKER_DOWNLOAD_ARCH="x86_64"
 fi
 
+mkdir -p /tmp/devcontainer-install/
 cd /tmp/devcontainer-install/
 
 # Download docker cli and install
@@ -42,3 +43,5 @@ apt install -y \
 
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 chsh --shell /bin/zsh root
+
+rm -rf /tmp/devcontainer-install/


### PR DESCRIPTION
The install script was doing `cd` to tmp folder without creating it. This PR creates the folder and deletes it at the end of the script